### PR TITLE
feat: add playable Library Noise Alarm puzzle with component selection, Blockly coding, and success evaluation

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Blockly from 'blockly';
+
+const CodeEditor = ({ spl, sampleIndex, onLog }) => {
+  const blocklyDiv = useRef(null);
+  const workspaceRef = useRef(null);
+  const codeRef = useRef('');
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    const toolbox = `
+      <xml xmlns="https://developers.google.com/blockly/xml">
+        <block type="read_spl"></block>
+        <block type="spl_greater"></block>
+        <block type="controls_if"></block>
+        <block type="logic_compare"></block>
+        <block type="math_number"></block>
+        <block type="led"></block>
+        <block type="buzzer"></block>
+      </xml>
+    `;
+
+    workspaceRef.current = Blockly.inject(blocklyDiv.current, { toolbox });
+
+    Blockly.Blocks['read_spl'] = {
+      init: function () {
+        this.appendDummyInput().appendField('read SPL');
+        this.setOutput(true, 'Number');
+        this.setColour(230);
+        this.setTooltip('Read sound pressure level from microphone');
+      }
+    };
+    Blockly.JavaScript['read_spl'] = function () {
+      return ['SPL_VALUE', Blockly.JavaScript.ORDER_ATOMIC];
+    };
+
+    Blockly.Blocks['spl_greater'] = {
+      init: function () {
+        this.appendValueInput('THRESH').setCheck('Number').appendField('SPL >');
+        this.setOutput(true, 'Boolean');
+        this.setColour(210);
+        this.setTooltip('Compare SPL to threshold');
+      }
+    };
+    Blockly.JavaScript['spl_greater'] = function (block) {
+      const value = Blockly.JavaScript.valueToCode(block, 'THRESH', Blockly.JavaScript.ORDER_NONE) || 0;
+      return [`SPL_VALUE > ${value}`, Blockly.JavaScript.ORDER_ATOMIC];
+    };
+
+    Blockly.Blocks['led'] = {
+      init: function () {
+        this.appendValueInput('STATE').setCheck('Boolean').appendField('set LED');
+        this.setPreviousStatement(true);
+        this.setNextStatement(true);
+        this.setColour(160);
+        this.setTooltip('Control LED');
+      }
+    };
+    Blockly.JavaScript['led'] = function (block) {
+      const state = Blockly.JavaScript.valueToCode(block, 'STATE', Blockly.JavaScript.ORDER_NONE) || 'false';
+      return `if(${state}) logEvent({type: 'alarm', component: 'led', state: true, index: SAMPLE_INDEX});\n`;
+    };
+
+    Blockly.Blocks['buzzer'] = {
+      init: function () {
+        this.appendValueInput('STATE').setCheck('Boolean').appendField('set buzzer');
+        this.setPreviousStatement(true);
+        this.setNextStatement(true);
+        this.setColour(20);
+        this.setTooltip('Control buzzer');
+      }
+    };
+    Blockly.JavaScript['buzzer'] = function (block) {
+      const state = Blockly.JavaScript.valueToCode(block, 'STATE', Blockly.JavaScript.ORDER_NONE) || 'false';
+      return `if(${state}) logEvent({type: 'alarm', component: 'buzzer', state: true, index: SAMPLE_INDEX});\n`;
+    };
+  }, []);
+
+  const run = () => {
+    codeRef.current = Blockly.JavaScript.workspaceToCode(workspaceRef.current);
+    setRunning(true);
+  };
+
+  useEffect(() => {
+    if (!running) return;
+    const interval = setInterval(() => {
+      const SPL_VALUE = spl;
+      const SAMPLE_INDEX = sampleIndex;
+      const logEvent = e => onLog(e);
+      try {
+        // eslint-disable-next-line no-eval
+        eval(codeRef.current);
+      } catch (e) {
+        console.error(e);
+      }
+    }, 100);
+    return () => clearInterval(interval);
+  }, [running, spl, sampleIndex, onLog]);
+
+  return (
+    <div className="code-editor">
+      <div ref={blocklyDiv} style={{ height: 300, width: 400 }} />
+      <button onClick={run}>Run</button>
+    </div>
+  );
+};
+
+export default CodeEditor;

--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+
+const Results = ({ log, puzzle }) => {
+  const [analysis, setAnalysis] = useState(null);
+
+  useEffect(() => {
+    const { threshold, minDurationMs, triggerWindowMs, maxFalseAlarms } = puzzle.successCondition;
+    const sampleInterval = 100; // ms per signalData sample
+    const minSamples = Math.ceil(minDurationMs / sampleInterval);
+    const windowSamples = Math.ceil(triggerWindowMs / sampleInterval);
+
+    // Determine noise events
+    const noiseStarts = [];
+    let count = 0;
+    for (let i = 0; i < puzzle.signalData.length; i++) {
+      if (puzzle.signalData[i] > threshold) {
+        count++;
+        if (count >= minSamples && (noiseStarts.length === 0 || noiseStarts[noiseStarts.length - 1] !== i - count + 1)) {
+          noiseStarts.push(i - count + 1);
+        }
+      } else {
+        count = 0;
+      }
+    }
+
+    // Alarm events from log
+    const alarms = [];
+    log.forEach(e => {
+      if (e.state) {
+        const last = alarms[alarms.length - 1];
+        if (last === undefined || e.index - last > 1) {
+          alarms.push(e.index);
+        }
+      }
+    });
+
+    let matched = 0;
+    noiseStarts.forEach(n => {
+      const match = alarms.find(a => a >= n && a <= n + windowSamples);
+      if (match !== undefined) matched++;
+    });
+
+    const falseAlarms = alarms.filter(a => !noiseStarts.some(n => a >= n && a <= n + windowSamples)).length;
+    const success = matched === noiseStarts.length && falseAlarms <= maxFalseAlarms;
+
+    setAnalysis({ success, matched, noiseEvents: noiseStarts.length, falseAlarms });
+  }, [log, puzzle]);
+
+  if (!analysis) return <div className="results"></div>;
+
+  return (
+    <div className="results">
+      <h3>Results: {analysis.success ? 'Pass' : 'Fail'}</h3>
+      <p>Detected {analysis.matched} of {analysis.noiseEvents} noise events</p>
+      <p>False alarms: {analysis.falseAlarms}</p>
+    </div>
+  );
+};
+
+export default Results;

--- a/src/components/Workbench.jsx
+++ b/src/components/Workbench.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react';
+import puzzles from '../data/puzzles.json';
+import CodeEditor from './CodeEditor';
+import Results from './Results';
+
+const Workbench = () => {
+  const puzzle = puzzles.find(p => p.id === 'library-noise');
+  const [placed, setPlaced] = useState([]);
+  const [index, setIndex] = useState(0);
+  const [spl, setSpl] = useState(puzzle.signalData[0]);
+  const [log, setLog] = useState([]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex(i => {
+        const next = (i + 1) % puzzle.signalData.length;
+        setSpl(puzzle.signalData[next]);
+        return next;
+      });
+    }, 100);
+    return () => clearInterval(interval);
+  }, [puzzle]);
+
+  const handleDragStart = e => {
+    e.dataTransfer.setData('component', e.target.dataset.component);
+  };
+
+  const handleDrop = e => {
+    const component = e.dataTransfer.getData('component');
+    setPlaced([...placed, component]);
+    e.preventDefault();
+  };
+
+  const allowDrop = e => e.preventDefault();
+
+  return (
+    <div className="workbench">
+      <h2>{puzzle.title}</h2>
+      <p>{puzzle.description}</p>
+      <div className="component-panel">
+        {puzzle.availableComponents.map(c => (
+          <div
+            key={c}
+            draggable
+            onDragStart={handleDragStart}
+            data-component={c}
+            className="component-item"
+          >
+            {c}
+          </div>
+        ))}
+      </div>
+      <div className="breadboard" onDrop={handleDrop} onDragOver={allowDrop}>
+        {placed.map((c, i) => (
+          <div key={i} className="placed-component">
+            {c}
+          </div>
+        ))}
+      </div>
+      <CodeEditor
+        spl={spl}
+        sampleIndex={index}
+        onLog={event => setLog(log => [...log, event])}
+      />
+      <Results log={log} puzzle={puzzle} />
+    </div>
+  );
+};
+
+export default Workbench;

--- a/src/data/puzzles.json
+++ b/src/data/puzzles.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "library-noise",
+    "title": "Library Noise Alarm",
+    "description": "Detect when the noise level in the library exceeds 45 dB.",
+    "availableComponents": ["microphone", "led", "buzzer", "resistor", "arduino"],
+    "signalType": "audio",
+    "signalData": [40, 42, 43, 46, 47, 48, 44, 41, 44, 50, 51, 49, 43, 42],
+    "successCondition": {
+      "threshold": 45,
+      "triggerWindowMs": 300,
+      "minDurationMs": 200,
+      "maxFalseAlarms": 2
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- introduce `library-noise` puzzle with SPL data, components, and success rules
- add Workbench to load puzzle, simulate microphone input, and support component drag-and-drop
- implement Blockly CodeEditor and Results evaluator for alarm detection

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6897d5cf535c832db7d7f2a4571214c8