### PR TITLE
feat: add initial game pages

### DIFF
--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-const Results = ({ log, puzzle }) => {
+const Results = ({ log, puzzle, onAnalysis }) => {
   const [analysis, setAnalysis] = useState(null)
 
   useEffect(() => {
@@ -51,13 +51,15 @@ const Results = ({ log, puzzle }) => {
     const success =
       matched === noiseStarts.length && falseAlarms <= maxFalseAlarms
 
-    setAnalysis({
+    const result = {
       success,
       matched,
       noiseEvents: noiseStarts.length,
       falseAlarms,
-    })
-  }, [log, puzzle])
+    }
+    setAnalysis(result)
+    onAnalysis?.(result)
+  }, [log, puzzle, onAnalysis])
 
   if (!analysis) return <div className="results"></div>
 

--- a/src/pages/CodeEditor.jsx
+++ b/src/pages/CodeEditor.jsx
@@ -1,5 +1,95 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import Blockly from 'blockly'
+import 'blockly/blocks'
+import 'blockly/javascript'
 
 export default function CodeEditor() {
-  return <h1>Code Editor</h1>
+  const blocklyDiv = useRef(null)
+  const workspaceRef = useRef(null)
+  const [textMode, setTextMode] = useState(false)
+  const [code, setCode] = useState('')
+  const [log, setLog] = useState([])
+
+  useEffect(() => {
+    workspaceRef.current = Blockly.inject(blocklyDiv.current, {
+      toolbox: `<xml xmlns="https://developers.google.com/blockly/xml">
+        <block type="controls_if"></block>
+        <block type="logic_compare"></block>
+        <block type="math_number"></block>
+        <block type="text_print"></block>
+      </xml>`,
+    })
+  }, [])
+
+  const generateCode = () => {
+    const generated = Blockly.JavaScript.workspaceToCode(workspaceRef.current)
+    setCode(generated)
+    return generated
+  }
+
+  const run = () => {
+    const generated = generateCode()
+    const output = []
+    const original = console.log
+    console.log = (...args) => output.push(args.join(' '))
+    try {
+      eval(generated)
+    } catch (e) {
+      output.push(`Error: ${e.message}`)
+    }
+    console.log = original
+    setLog(output)
+  }
+
+  const reset = () => {
+    workspaceRef.current.clear()
+    setLog([])
+    setCode('')
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <button
+          onClick={run}
+          className="px-3 py-1 bg-primary text-white rounded"
+        >
+          Run
+        </button>
+        <button
+          onClick={reset}
+          className="px-3 py-1 bg-secondary text-white rounded"
+        >
+          Reset
+        </button>
+        <button
+          onClick={() => {
+            generateCode()
+            setTextMode((m) => !m)
+          }}
+          className="px-3 py-1 bg-accent text-white rounded"
+        >
+          {textMode ? 'Blocks' : 'Text'}
+        </button>
+      </div>
+      <div className="flex gap-4">
+        <div
+          ref={blocklyDiv}
+          className={`flex-1 h-72 ${textMode ? 'hidden' : 'block'}`}
+        ></div>
+        {textMode && (
+          <textarea
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            className="flex-1 h-72 border p-2 font-mono"
+          />
+        )}
+      </div>
+      <div className="border p-2 h-32 overflow-auto bg-black text-green-400 text-sm">
+        {log.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,36 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 export default function Home() {
-  return <h1>Home</h1>
+  const stats = JSON.parse(
+    localStorage.getItem('stats') || '{"played":0,"won":0}'
+  )
+
+  return (
+    <div className="text-center space-y-6">
+      <h1 className="text-3xl font-bold">Circuit Case Files</h1>
+      <p className="max-w-xl mx-auto">
+        Solve playful hardware puzzles using a virtual breadboard and code.
+      </p>
+      <div className="flex justify-center gap-4">
+        <Link
+          to="/play?mode=daily"
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          Play Daily
+        </Link>
+        <Link
+          to="/play?mode=endless"
+          className="px-4 py-2 bg-secondary text-white rounded"
+        >
+          Play Endless
+        </Link>
+      </div>
+      <div className="mt-8">
+        <h2 className="font-semibold mb-2">Stats</h2>
+        <p>Games Played: {stats.played}</p>
+        <p>Wins: {stats.won}</p>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/Play.jsx
+++ b/src/pages/Play.jsx
@@ -1,5 +1,29 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import puzzles from '../data/puzzles.json'
+import { useGameStore } from '../state/useGameStore'
 
 export default function Play() {
-  return <div>Play Page</div>
+  const location = useLocation()
+  const mode = new URLSearchParams(location.search).get('mode') || 'daily'
+  const puzzle = puzzles[0]
+  const setPuzzle = useGameStore((s) => s.setPuzzle)
+
+  useEffect(() => {
+    setPuzzle(puzzle)
+  }, [puzzle, setPuzzle])
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{puzzle.title}</h1>
+      <p>{puzzle.description}</p>
+      <p className="text-sm text-gray-600">Mode: {mode}</p>
+      <Link
+        to="/workbench"
+        className="inline-block px-4 py-2 bg-primary text-white rounded"
+      >
+        Start Workbench
+      </Link>
+    </div>
+  )
 }

--- a/src/pages/Results.jsx
+++ b/src/pages/Results.jsx
@@ -1,5 +1,38 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import puzzles from '../data/puzzles.json'
+import ResultsAnalysis from '../components/Results'
 
 export default function Results() {
-  return <h1>Results</h1>
+  const location = useLocation()
+  const { log = [] } = location.state || {}
+  const puzzle = puzzles[0]
+  const [analysis, setAnalysis] = useState(null)
+
+  const share = () => {
+    if (!analysis) return
+    const text = `Circuit Case Files: ${analysis.success ? 'Success' : 'Fail'} - ` +
+      `${analysis.matched}/${analysis.noiseEvents} events`
+    navigator.clipboard.writeText(text)
+  }
+
+  return (
+    <div className="space-y-4">
+      <ResultsAnalysis log={log} puzzle={puzzle} onAnalysis={setAnalysis} />
+      <div className="flex gap-4">
+        <button
+          onClick={share}
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          Share
+        </button>
+        <Link
+          to="/play"
+          className="px-4 py-2 bg-secondary text-white rounded"
+        >
+          Play Again
+        </Link>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/Workbench.jsx
+++ b/src/pages/Workbench.jsx
@@ -1,5 +1,21 @@
 import React from 'react'
+import Breadboard from '../components/Breadboard'
+import ArduinoBoard from '../components/ArduinoBoard'
+import ComponentPanel from '../components/ComponentPanel'
 
 export default function Workbench() {
-  return <h1>Workbench</h1>
+  return (
+    <div className="flex gap-4">
+      <ComponentPanel />
+      <div className="flex flex-col flex-1 gap-4">
+        <div className="flex flex-1 gap-4">
+          <Breadboard />
+          <ArduinoBoard />
+        </div>
+        <button className="self-start px-3 py-1 bg-accent text-white rounded">
+          Hint
+        </button>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- scaffold home page with intro and daily/endless play links
- add play page that loads puzzle info and routes to workbench
- implement workbench, code editor, and results pages with basic UI and wiring stubs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f62bf198832dbfa0ca8c8d881eb5