### PR TITLE
feat: add core UI components

### DIFF
--- a/src/components/AnimatedScene.jsx
+++ b/src/components/AnimatedScene.jsx
@@ -1,9 +1,31 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+
+// Simple animated scene using a canvas with a bouncing dot.
 
 export default function AnimatedScene() {
+  const canvasRef = useRef(null)
+
   useEffect(() => {
-    // placeholder for animation loop
+    const canvas = canvasRef.current
+    const ctx = canvas.getContext('2d')
+    let x = 0
+    let raf
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.fillStyle = '#3490dc'
+      ctx.beginPath()
+      ctx.arc(x, 40, 10, 0, Math.PI * 2)
+      ctx.fill()
+      x = (x + 2) % canvas.width
+      raf = requestAnimationFrame(draw)
+    }
+
+    draw()
+    return () => cancelAnimationFrame(raf)
   }, [])
 
-  return <div className="border p-4 flex-1">Animated Scene</div>
+  return (
+    <canvas ref={canvasRef} width={200} height={80} className="border flex-1" />
+  )
 }

--- a/src/components/ArduinoBoard.jsx
+++ b/src/components/ArduinoBoard.jsx
@@ -1,3 +1,62 @@
+import { useState } from 'react'
+
+// Simplified Arduino UNO representation with pins and tooltips
+
+const analogPins = ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']
+const digitalPins = [
+  'D2',
+  'D3',
+  'D4',
+  'D5',
+  'D6',
+  'D7',
+  'D8',
+  'D9',
+  'D10',
+  'D11',
+  'D12',
+  'D13',
+]
+const powerPins = ['5V', '3V3', 'GND', 'VIN']
+
+function Pin({ label }) {
+  const [hover, setHover] = useState(false)
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <div className="w-8 h-8 bg-gray-200 rounded flex items-center justify-center text-xs">
+        {label}
+      </div>
+      {hover && (
+        <div className="absolute -top-6 left-1/2 -translate-x-1/2 bg-black text-white text-xs px-1 rounded">
+          {label}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function ArduinoBoard() {
-  return <div className="border p-4 flex-1">Arduino Board</div>
+  return (
+    <div className="border p-4 flex flex-col gap-2 flex-1">
+      <div className="flex flex-wrap gap-1">
+        {analogPins.map((p) => (
+          <Pin key={p} label={p} />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {digitalPins.map((p) => (
+          <Pin key={p} label={p} />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-1 mt-2">
+        {powerPins.map((p) => (
+          <Pin key={p} label={p} />
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/src/components/Breadboard.jsx
+++ b/src/components/Breadboard.jsx
@@ -1,3 +1,39 @@
-export default function Breadboard() {
-  return <div className="border p-4 flex-1">Breadboard</div>
+import { useState } from 'react'
+
+// Simple breadboard grid with drag / drop highlight support
+// This is a minimal placeholder for the eventual interactive breadboard
+
+const ROWS = 10
+const COLS = 30
+
+export default function Breadboard({ onCellDrop }) {
+  const [hoverIndex, setHoverIndex] = useState(null)
+
+  const handleDragOver = (e, index) => {
+    e.preventDefault()
+    setHoverIndex(index)
+  }
+
+  const handleDragLeave = () => setHoverIndex(null)
+
+  const handleDrop = (e, index) => {
+    e.preventDefault()
+    const component = e.dataTransfer.getData('component')
+    setHoverIndex(null)
+    if (onCellDrop) onCellDrop({ component, index })
+  }
+
+  const cells = Array.from({ length: ROWS * COLS }, (_, i) => (
+    <div
+      key={i}
+      onDragOver={(e) => handleDragOver(e, i)}
+      onDragLeave={handleDragLeave}
+      onDrop={(e) => handleDrop(e, i)}
+      className={`w-4 h-4 border border-gray-300 ${
+        hoverIndex === i ? 'bg-yellow-200' : 'bg-white'
+      }`}
+    />
+  ))
+
+  return <div className="p-2 border flex flex-wrap w-[260px]">{cells}</div>
 }

--- a/src/components/ComponentPanel.jsx
+++ b/src/components/ComponentPanel.jsx
@@ -1,3 +1,35 @@
-export default function ComponentPanel() {
-  return <div className="border p-4 w-48">Component Panel</div>
+import { useState } from 'react'
+
+// Panel listing available components. Items are draggable onto the workbench.
+// Includes an "Advanced" toggle to reveal additional components.
+
+export default function ComponentPanel({ components = [], advanced = [] }) {
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const items = [...components, ...(showAdvanced ? advanced : [])]
+
+  return (
+    <div className="border p-4 w-48">
+      <h3 className="font-bold mb-2">Components</h3>
+      <ul className="space-y-1 mb-2">
+        {items.map((c) => (
+          <li
+            key={c}
+            draggable
+            data-component={c}
+            className="p-1 border rounded text-sm bg-white hover:bg-gray-50 cursor-move"
+          >
+            {c}
+          </li>
+        ))}
+      </ul>
+      {advanced.length > 0 && (
+        <button
+          onClick={() => setShowAdvanced((s) => !s)}
+          className="text-xs text-primary underline"
+        >
+          {showAdvanced ? 'Hide advanced' : 'Advanced'}
+        </button>
+      )}
+    </div>
+  )
 }

--- a/src/components/HintPopover.jsx
+++ b/src/components/HintPopover.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+// Shows tiered hints in a small popover
+
+export default function HintPopover({ hints = [] }) {
+  const [open, setOpen] = useState(false)
+  const [index, setIndex] = useState(0)
+  const current = hints[index]
+
+  const next = () => {
+    setIndex((i) => Math.min(i + 1, hints.length - 1))
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        className="px-3 py-1 bg-accent text-white rounded"
+        onClick={() => setOpen((o) => !o)}
+      >
+        Hint
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-2 w-48 p-2 bg-white border rounded shadow">
+          <p className="text-sm">{current || 'No more hints'}</p>
+          {current && index < hints.length - 1 && (
+            <button className="mt-2 text-xs text-primary" onClick={next}>
+              Next hint
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/SignalVisualizer.jsx
+++ b/src/components/SignalVisualizer.jsx
@@ -1,16 +1,46 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { FFT } from 'dsp.js'
 
+// Visualizes waveform and FFT spectrum of provided data array
+
 export default function SignalVisualizer({ data = [] }) {
+  const waveRef = useRef(null)
+  const fftRef = useRef(null)
+
   useEffect(() => {
-    if (data.length) {
-      const fft = new FFT(1024, 44100)
-      const segment = data.slice(0, 1024)
-      while (segment.length < 1024) segment.push(0)
-      fft.forward(segment)
-      console.log('FFT Spectrum', fft.spectrum)
+    if (!data.length) return
+
+    const waveCtx = waveRef.current.getContext('2d')
+    waveCtx.clearRect(0, 0, 200, 80)
+    waveCtx.strokeStyle = '#10b981'
+    waveCtx.beginPath()
+    data.slice(0, 200).forEach((v, i) => {
+      const x = (i / 200) * 200
+      const y = 40 - v * 40
+      if (i === 0) waveCtx.moveTo(x, y)
+      else waveCtx.lineTo(x, y)
+    })
+    waveCtx.stroke()
+
+    const fft = new FFT(1024, 44100)
+    const segment = data.slice(0, 1024)
+    while (segment.length < 1024) segment.push(0)
+    fft.forward(segment)
+    const spec = fft.spectrum
+
+    const fftCtx = fftRef.current.getContext('2d')
+    fftCtx.clearRect(0, 0, 200, 80)
+    fftCtx.fillStyle = '#3b82f6'
+    for (let i = 0; i < Math.min(spec.length, 200); i++) {
+      const h = spec[i] * 4000
+      fftCtx.fillRect(i, 80 - h, 1, h)
     }
   }, [data])
 
-  return <div className="border p-4 flex-1">Signal Visualizer</div>
+  return (
+    <div className="border p-2 flex gap-2 flex-1">
+      <canvas ref={waveRef} width={200} height={80} className="bg-white" />
+      <canvas ref={fftRef} width={200} height={80} className="bg-white" />
+    </div>
+  )
 }

--- a/src/components/TourOverlay.jsx
+++ b/src/components/TourOverlay.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+// Simple three-step tour overlay guiding the user through core actions
+
+const steps = [
+  'Place the microphone on the breadboard',
+  'Wire the microphone signal to pin A0',
+  'Add a threshold block in the code editor and run',
+]
+
+export default function TourOverlay({ onFinish }) {
+  const [step, setStep] = useState(0)
+
+  if (step >= steps.length) return null
+
+  const next = () => {
+    if (step >= steps.length - 1) {
+      if (onFinish) onFinish()
+    }
+    setStep((s) => s + 1)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded shadow w-80 text-center space-y-4">
+        <p>{steps[step]}</p>
+        <button
+          onClick={next}
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          {step === steps.length - 1 ? 'Finish' : 'Next'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/WireCanvas.jsx
+++ b/src/components/WireCanvas.jsx
@@ -1,0 +1,57 @@
+import { useRef, useState } from 'react'
+
+// Very lightweight wire drawing canvas. Users click to start and end a wire.
+// Wires snap to a 10px grid.
+
+function snap(value) {
+  return Math.round(value / 10) * 10
+}
+
+export default function WireCanvas() {
+  const svgRef = useRef(null)
+  const [start, setStart] = useState(null)
+  const [wires, setWires] = useState([])
+  const [hover, setHover] = useState(null)
+
+  const handleClick = (e) => {
+    const rect = svgRef.current.getBoundingClientRect()
+    const point = {
+      x: snap(e.clientX - rect.left),
+      y: snap(e.clientY - rect.top),
+    }
+    if (!start) {
+      setStart(point)
+    } else {
+      setWires([
+        ...wires,
+        { x1: start.x, y1: start.y, x2: point.x, y2: point.y },
+      ])
+      setStart(null)
+    }
+  }
+
+  return (
+    <svg
+      ref={svgRef}
+      width={260}
+      height={160}
+      className="absolute inset-0"
+      onClick={handleClick}
+    >
+      {wires.map((w, i) => (
+        <line
+          key={i}
+          x1={w.x1}
+          y1={w.y1}
+          x2={w.x2}
+          y2={w.y2}
+          stroke={hover === i ? '#0f0' : '#f00'}
+          strokeWidth="2"
+          onMouseEnter={() => setHover(i)}
+          onMouseLeave={() => setHover(null)}
+        />
+      ))}
+      {start && <circle cx={start.x} cy={start.y} r={3} fill="blue" />}
+    </svg>
+  )
+}

--- a/src/pages/Workbench.jsx
+++ b/src/pages/Workbench.jsx
@@ -2,20 +2,34 @@ import React from 'react'
 import Breadboard from '../components/Breadboard'
 import ArduinoBoard from '../components/ArduinoBoard'
 import ComponentPanel from '../components/ComponentPanel'
+import WireCanvas from '../components/WireCanvas'
+import HintPopover from '../components/HintPopover'
+import TourOverlay from '../components/TourOverlay'
 
 export default function Workbench() {
+  const hints = [
+    'Place the microphone on the breadboard',
+    'Connect its output to pin A0',
+    'Use a threshold block and run the program',
+  ]
+
   return (
-    <div className="flex gap-4">
-      <ComponentPanel />
-      <div className="flex flex-col flex-1 gap-4">
-        <div className="flex flex-1 gap-4">
-          <Breadboard />
+    <div className="flex gap-4 relative">
+      <ComponentPanel
+        components={['LED', 'Buzzer', 'Mic']}
+        advanced={['Accelerometer']}
+      />
+      <div className="flex flex-col flex-1 gap-4 relative">
+        <div className="flex flex-1 gap-4 relative">
+          <div className="relative">
+            <Breadboard />
+            <WireCanvas />
+          </div>
           <ArduinoBoard />
         </div>
-        <button className="self-start px-3 py-1 bg-accent text-white rounded">
-          Hint
-        </button>
+        <HintPopover hints={hints} />
       </div>
+      <TourOverlay />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement drag-and-drop breadboard grid and Arduino pin view
- add component panel, wire canvas, hint popover, and tour overlay
- draw simple animated scene and signal visualizer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6897f83e3a78832db92f9c4fbf4af04d